### PR TITLE
fix for php >= 8.1: change of preg_split

### DIFF
--- a/support/Compressor.php
+++ b/support/Compressor.php
@@ -235,7 +235,7 @@ class Minify_CSS_Compressor {
     protected function _fontFamilyCB($m)
     {
         // Issue 210: must not eliminate WS between words in unquoted families
-        $pieces = preg_split('/(\'[^\']+\'|"[^"]+")/', $m[1], null, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $pieces = preg_split('/(\'[^\']+\'|"[^"]+")/', $m[1], -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
         $out = 'font-family:';
         while (null !== ($piece = array_shift($pieces))) {
             if ($piece[0] !== '"' && $piece[0] !== "'") {


### PR DESCRIPTION
php deprecated passing null to non-nullable parameters of built-in functions, see [here](https://www.php.net/manual/en/migration81.deprecated.php#migration81.deprecated.core.null-not-nullable-internal).

Hence I changed the third parameter of preg_split() in Compressor.php to -1 instead of null. That should be backwards compatible.